### PR TITLE
Added edit article for admins

### DIFF
--- a/SocialMedia.API/Controllers/ArticlesController.cs
+++ b/SocialMedia.API/Controllers/ArticlesController.cs
@@ -26,7 +26,23 @@ public class ArticlesController : ControllerBase
     {
         try
         {
-            await _service.AddArticle(request.ToAddRegisterDTO());
+            await _service.AddArticle(request.ToAddArticleDTO());
+            
+            return Ok();
+        }
+        catch
+        {
+            return BadRequest();
+        }
+    }
+    
+    [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme, Roles = "Admin")]
+    [HttpPost("edit")]
+    public async Task<IActionResult> EditRequest([FromBody] EditArticleRequest request)
+    {
+        try
+        {
+            await _service.EditArticle(request.ToEditArticleDTO());
             
             return Ok();
         }

--- a/SocialMedia.API/Requests/Articles/ArticlesExtensions.cs
+++ b/SocialMedia.API/Requests/Articles/ArticlesExtensions.cs
@@ -6,11 +6,19 @@ namespace SocialMedia.API.Requests.Articles;
 
 public static class ArticlesExtensions
 {
-    public static AddArticleDTO ToAddRegisterDTO(this AddArticleRequest request) =>
+    public static AddArticleDTO ToAddArticleDTO(this AddArticleRequest request) =>
         new AddArticleDTO
         {
             Title = request.Title,
             Author = request.Author,
+            Content = request.Content
+        };
+    
+    public static EditArticleDTO ToEditArticleDTO(this EditArticleRequest request) =>
+        new EditArticleDTO
+        {
+            ArticleId = request.ArticleId,
+            Title = request.Title,
             Content = request.Content
         };
     

--- a/SocialMedia.API/Requests/Articles/EditArticleRequest.cs
+++ b/SocialMedia.API/Requests/Articles/EditArticleRequest.cs
@@ -1,0 +1,8 @@
+namespace SocialMedia.API.Requests.Articles;
+
+public class EditArticleRequest
+{
+    public int ArticleId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+}

--- a/SocialMedia.Business/Models/Articles/EditArticleDTO.cs
+++ b/SocialMedia.Business/Models/Articles/EditArticleDTO.cs
@@ -1,0 +1,8 @@
+namespace SocialMedia.Business.Models.Articles;
+
+public class EditArticleDTO
+{
+    public int ArticleId { get; set; }
+    public string Title { get; set; }
+    public string Content { get; set; }
+}

--- a/SocialMedia.Business/Services/Articles/ArticlesService.cs
+++ b/SocialMedia.Business/Services/Articles/ArticlesService.cs
@@ -36,6 +36,19 @@ public class ArticlesService: IArticlesService
         _dbContext.SaveChanges();
     }
     
+    public async Task EditArticle(EditArticleDTO request)
+    {
+        var article = await _dbContext.Articles.FirstOrDefaultAsync(article => article.ArticleId == request.ArticleId);
+
+        if (article == null)
+            return;
+
+        article.Title = request.Title;
+        article.Content = request.Content;
+        
+        await _dbContext.SaveChangesAsync();
+    }
+    
     public async Task<string> AddImage(IFormFile image)
     {
         if (image != null && image.Length > 0)

--- a/SocialMedia.Business/Services/Articles/IArticlesService.cs
+++ b/SocialMedia.Business/Services/Articles/IArticlesService.cs
@@ -8,6 +8,7 @@ namespace SocialMedia.Business.Services.Articles;
 public interface IArticlesService
 {
     Task AddArticle(AddArticleDTO request);
+    Task EditArticle(EditArticleDTO request);
     Task<string> AddImage(IFormFile image);
     Task<Article> GetArticle(int articleId);
     Task<FilterResponse<Article>> GetFilteredArticles(FilterObjectDTO request);
@@ -15,3 +16,4 @@ public interface IArticlesService
     Task<int> GetLatestArticleId();
 }
 
+    


### PR DESCRIPTION
This pull request introduces functionality to edit articles in the `SocialMedia` application. It adds a new API endpoint, data transfer objects, and service methods to support this feature while also refining existing code. Below are the most important changes grouped by theme:

### API Enhancements:
* Added a new `EditRequest` endpoint in `ArticlesController` to handle article edits. This endpoint uses the `EditArticleRequest` model and calls the `EditArticle` service method.

### Data Transfer Objects:
* Introduced `EditArticleRequest` in `SocialMedia.API.Requests.Articles` to represent the request payload for editing articles.
* Added `EditArticleDTO` in `SocialMedia.Business.Models.Articles` to encapsulate the data passed to the business layer for article edits.

### Service Layer Updates:
* Implemented the `EditArticle` method in `ArticlesService` to update article details in the database. The method checks for the existence of the article and updates its title and content.
* Updated `IArticlesService` to include the new `EditArticle` method, ensuring the service interface supports the new functionality.

### Code Refinement:
* Renamed the `ToAddRegisterDTO` extension method to `ToAddArticleDTO` for better clarity and added a new `ToEditArticleDTO` extension method for converting `EditArticleRequest` to `EditArticleDTO`.